### PR TITLE
Ajusta leitura de Json e CI para executar apenas em PRs

### DIFF
--- a/.github/workflows/bot-ci.yml
+++ b/.github/workflows/bot-ci.yml
@@ -3,9 +3,6 @@ on:
   pull_request:
     branches:
     - main
-  push:
-    branches:
-    - main
 jobs:
   bot-ci:
     runs-on: ubuntu-latest

--- a/services/songs_counter.py
+++ b/services/songs_counter.py
@@ -34,7 +34,7 @@ class SongsCounter(metaclass=MetaClassSongsCounter):
         try:
             with open("contador.json", "r", encoding="utf-8") as songs:
                 return loads(songs.read())
-        except (JSONDecodeError, TypeError, ValueError) as e:
+        except (JSONDecodeError, TypeError, ValueError, FileNotFoundError) as e:
             print("Erro ao Carregar contador de músicas, usando um genérico", e)
             self.fail = True
             return {}


### PR DESCRIPTION
fix[workflow]: CI deixa de executar no push, executa apenas no Pull Request

fix: inicialização do contador de músicas caso json não exista    
    O bloco de try-except não tratava o erro para FileNotFound